### PR TITLE
Various fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,7 @@
 
 ## So, why should I care?
 
-Since the advent of systems such as [Stable Diffusion](https://stability.ai/blog/stable-diffusion-public-release), [Midjourney](https://www.midjourney.com/home/), and [DallE-2](https://openai.com/dall-e-2) text-to-image generation  
-models have taken the world by storm.
+Since the advent of systems such as [Stable Diffusion](https://stability.ai/blog/stable-diffusion-public-release), [Midjourney](https://www.midjourney.com/home/), and [DallE-2](https://openai.com/dall-e-2) text-to-image generation models have taken the world by storm.
 
 However, evaluation of the quality of these systems still remains one of the
 hardest challenges in continuing to improve them as there is a lack of standardization and robust tooling.
@@ -46,7 +45,6 @@ We also provide a simple and ready-to-use [Streamlit](https://streamlit.io/) int
 This library has been tested on Python 3.9.12. Installing the library involves running:
 ```
 pip install image-eval
-pip install git+https://github.com/openai/CLIP.git # A dependency some metrics require
 ```
 
 Optionally, if you have a CUDA-enabled device, install the [version of PyTorch](https://pytorch.org/get-started/previous-versions/) that matches your CUDA version. For CUDA 11.3, that might look like:
@@ -54,38 +52,18 @@ Optionally, if you have a CUDA-enabled device, install the [version of PyTorch](
 pip install torch==1.12.1+cu113 torchvision==0.13.1+cu113 --extra-index-url https://download.pytorch.org/whl/cu113
 ```
 
-NOTE: If you want to use the `aesthetic_predictor` and `human_preference_score` metrics, you will need to download the respective model weights.
-
-We require having a `models` folder and then having a separate subfolder for `aesthetic_predictor` and `human_preference_score` with the downloaded weights.
-
-For `aesthetic_predictor` you can download the weights of the model [here](https://github.com/christophschuhmann/improved-aesthetic-predictor/blob/main/sac%2Blogos%2Bava1-l14-linearMSE.pth).
-
-For `human_preference_score` you can download the weights of the model [here](https://mycuhk-my.sharepoint.com/:u:/g/personal/1155172150_link_cuhk_edu_hk/EWDmzdoqa1tEgFIGgR5E7gYBTaQktJcxoOYRoTHWzwzNcw?e=b7rgYW).
-
-Your `models` folder should then have this structure:
-```
-models/
-├── aesthetic_predictor/
-│   └── sac+logos+ava1-l14-linearMSE.pth
-└── human_preference_score/
-    └── hpc.pt
-```
-
-You can then specify your `models` folder in the [usage](#usage) section below.
-
 ## Usage
 
 There are two ways to interact with the `image-eval` library: either through the CLI or through the API.
 
 ### CLI
 
-You can invoke all the metric computations through the CLI once you've `pip install`'d the library. The library makes certain
-assumptions about the format of the inputs to the CLI.
+You can invoke all the metric computations through the CLI once you've `pip install`'d the library. The library makes certain assumptions about the format of the inputs to the CLI.
 
 For example, if you want to calculate a metric assessing the match between
 prompts and generated images (as is the case with `clip_score`), you would invoke:
 ```
-image_eval -m clip_score -p /path/to/image_to_prompt.json -g /path/to/folder/with/generated/images 
+image_eval -m clip_score -p /path/to/image_to_prompt.json -g /path/to/folder/with/generated/images
 ```
 
 Here `image_to_prompt.json` is a JSON file with the following format:
@@ -102,11 +80,6 @@ where `image_1.jpg` and `image_2.jpg` are the names of the generated images in t
 If you want to calculate a metric assessing the match between generated images and a set of reference images (as is the case with `fid`), you would invoke:
 ```
 image_eval -m fid -g /path/to/generated/images -r /path/to/real/images
-```
-
-Some metrics may need you to specify additional arguments. For example, if you want to use the `aesthetic_predictor` or `human_preference_score` metrics, you would invoke:
-```
-image_eval -m aesthetic_predictor -p /path/to/image_to_prompt.json -g /path/to/generated/images --model-dir /path/to/folder/with/models
 ```
 
 You can also compute multiple metrics simultaneously by passing in a comma-separated list of metrics to the `-m` flag:

--- a/image_eval/evaluators.py
+++ b/image_eval/evaluators.py
@@ -67,14 +67,15 @@ class CLIPSimilarityEvaluator(BaseWithReferenceEvaluator):
         generated_images_inputs = self.processor(text=None, images=generated_images, return_tensors="pt", padding=True)
         generated_images_inputs = {k: v.to(self.device) for k, v in generated_images_inputs.items()}
         generated_images_embeddings = self.model.get_image_features(**generated_images_inputs)
+        generated_images_center = torch.mean(generated_images_embeddings, axis=0, keepdim=True)
 
         real_images_inputs = self.processor(text=None, images=real_images, return_tensors="pt", padding=True)
         real_images_inputs = {k: v.to(self.device) for k, v in real_images_inputs.items()}
         real_images_embeddings = self.model.get_image_features(**real_images_inputs)
-
         real_images_center = torch.mean(real_images_embeddings, axis=0, keepdim=True)
+
         cos = torch.nn.CosineSimilarity(dim=1, eps=1e-6)
-        similarities = cos(real_images_center, generated_images_embeddings)
+        similarities = cos(real_images_center, generated_images_center)
         return torch.mean(similarities)
 
 

--- a/image_eval/improved_aesthetic_predictor.py
+++ b/image_eval/improved_aesthetic_predictor.py
@@ -62,10 +62,8 @@ def normalized(a, axis=-1, order=2):
     return a / np.expand_dims(l2, axis)
 
 
-def run_inference(images: list[Image], device: str):
+def run_inference(images: list[Image.Image], model_path: str, device: str):
     model = MLP(768)  # CLIP embedding dim is 768 for CLIP ViT L 14
-    # load the model you trained previously or the model available in this repo
-    model_path = os.path.join(os.environ["MODELS_DIR"], "aesthetic_predictor/sac+logos+ava1-l14-linearMSE.pth")
     if torch.cuda.is_available():
         s = torch.load(model_path)
     else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-clip==0.2.0
+git+https://github.com/openai/CLIP.git
 image-reward==1.5
 lpips==0.1.4
 networkx==3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ networkx==3.1
 numpy
 piq==0.8.0
 pytorch-lightning==2.0.8
+requests==2.31.0
 scikit-learn==1.3.2
 streamlit==1.26.0
 sympy==1.12


### PR DESCRIPTION
1. Flag cleanup:
- Clearly mark requried flags (otherwise we fail with more obscure errors)
- Default "--metrics" to "all", so that the user doesn't need to enumerate
- Add "--aesthetic-predictor-model-url" and "--human-preference-score-model-url" with defaults

2. Change the interface of the evaluators:
- Add an optional "model_path" to the constructor; this is pretty natural and I suspect we'll add other model-dependent metrics in the future.
- evaluate() now takes list[Image.Image] instead of list[Union[Image.Image, np.array]]. Each evaluator will just convert the Image.Image objects directly to tensors, if needed. This drastically simplifies the logic of calling them.

3. Smaller nits:
- Don't choke if the -g or -r folders contain non-image files; just ignore them
- Fix requirements
- Add missing .to(self.device) statements in CLIPSimilarityEvaluator
- Allow real images to have various sizes (resize them to the size of generated images)